### PR TITLE
Switch post column status names

### DIFF
--- a/includes/class-lbn-post.php
+++ b/includes/class-lbn-post.php
@@ -74,8 +74,8 @@ class LBN_Post {
 	 */
 	public function build_column( $columns, $post_id ) {
 
-		$prod_status  = (bool) get_post_meta( $post_id, 'lbn_published_stage', true );
-		$stage_status = (bool) get_post_meta( $post_id, 'lbn_published_production', true );
+		$stage_status  = (bool) get_post_meta( $post_id, 'lbn_published_stage', true );
+		$prod_status = (bool) get_post_meta( $post_id, 'lbn_published_production', true );
 
 		if ( $prod_status ) {
 			echo sprintf( '<div>%s</div>', esc_html( 'Production', 'lb-netlifly' ) );


### PR DESCRIPTION
These are the wrong way round so the columns display the opposite value in Wordpress admin